### PR TITLE
Substitute "inequalities" for "inequation"

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -7638,7 +7638,7 @@ the~$f_i$ being invertible by locality of~$\affl$.
 
 The internal condition appearing in the corollary reflects basic intuition
 about openness in algebraic geometry: Intuitively, a subset is open if it is
-given by inequations,
+given by inequalities,
 so that to decide whether a point belongs to the subset one has to check that
 at least one of some numbers is not zero.
 


### PR DESCRIPTION
That word is weird. Also "inequalities" fits perfectly well in that sentence.